### PR TITLE
Add support for newer python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,6 @@
 
 ### End of Ash adds
 
-### Sam Added
-### Because of using venv
-Scripts
-pyvenv.cfg
-### End of Sam adds
-
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 
 ### End of Ash adds
 
+### Sam Added
+### Because of using venv
+Scripts
+pyvenv.cfg
+### End of Sam adds
+
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/coast_core/clarity_of_writing.py
+++ b/coast_core/clarity_of_writing.py
@@ -4,21 +4,12 @@ A collection of functions that can be used for analysing the clarity of writing 
 
 from textstat.textstat import textstat
 import nltk
-import language_check
+import language_tool_python #import language_check
 from textblob import TextBlob
-from langdetect import detect  # breaks the build
-
 
 def detect_language(text):
-    """
-    Given a body of text, will use the langdetect library to detect the text language and return.
-
-    :param text: The body of text to analyse.
-    :return: The language code (e.g. EN for English).
-    """
-    lang_code = detect(text)
-
-    return lang_code
+    blob = TextBlob(text)
+    return blob.detect_language()
 
 
 def analyse_readability_metrics(article_text):
@@ -119,14 +110,14 @@ def analyse_readability_metrics(article_text):
 
 def analyse_text_for_grammatical_metrics(article_text):
     """
-    Use the language_check library to check a body of text for grammatical issues.
+    Use the language_tool_python library to check a body of text for grammatical issues.
 
     :param article_text: The text to be analyse.
 
     :return: The total number of grammatical issues found. A list containing details of each grammatical issue. A list of sentences, tokenized by NLTK.
     """
     try:
-        tool = language_check.LanguageTool('en-US')
+        tool = language_tool_python.LanguageTool('en-US')
 
         sentences = nltk.sent_tokenize(article_text)
 

--- a/coast_core/clarity_of_writing.py
+++ b/coast_core/clarity_of_writing.py
@@ -6,6 +6,7 @@ of writing within an article.
 from textstat.textstat import textstat
 import nltk
 import language_tool_python  # import language_check
+from textblob import TextBlob
 import langid
 
 

--- a/coast_core/clarity_of_writing.py
+++ b/coast_core/clarity_of_writing.py
@@ -1,15 +1,17 @@
 """
-A collection of functions that can be used for analysing the clarity of writing within an article
+A collection of functions that can be used for analysing the clarity
+of writing within an article.
 """
 
 from textstat.textstat import textstat
 import nltk
-import language_tool_python #import language_check
-from textblob import TextBlob
+import language_tool_python  # import language_check
+import langid
+
 
 def detect_language(text):
-    blob = TextBlob(text)
-    return blob.detect_language()
+    lang, confidence = langid.classify(text)
+    return lang
 
 
 def analyse_readability_metrics(article_text):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ nltk
 language_tool_python
 textblob
 sphinx_rtd_theme
+langid

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ bs4
 html5lib
 textstat
 nltk
-language_check
+language_tool_python
 textblob
-langdetect
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst", encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open("HISTORY.rst", encoding='utf-8') as history_file:
     history = history_file.read()
 
 requirements = [
@@ -17,46 +17,42 @@ requirements = [
     "html5lib",
     "textstat",
     "nltk",
-    "language_check",
-    "textblob",
-    "langdetect"
+    "language-tool-python",
+    "textblob"
 ]
 
-setup_requirements = [
-]
+setup_requirements = []
 
-test_requirements = [
-]
+test_requirements = []
 
-dependency_links = [
-]
+dependency_links = []
 
 setup(
     author="Ashley Williams",
-    author_email='ashley.williams@pg.canterbury.ac.nz',
+    author_email="ashley.williams@pg.canterbury.ac.nz",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
     description="Core functionality of COAST",
     install_requires=requirements,
     license="MIT license",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     include_package_data=True,
-    keywords='coast_core',
-    name='coast_core',
-    packages=find_packages(include=['coast_core']),
+    keywords="coast_core",
+    name="coast_core",
+    packages=find_packages(include=["coast_core"]),
     setup_requires=setup_requirements,
-    test_suite='tests',
+    test_suite="tests",
     tests_require=test_requirements,
-    url='https://github.com/zedrem/coast_core',
-    version='1.0.1',
+    url="https://github.com/zedrem/coast_core",
+    version="1.0.1",
     zip_safe=False,
-    dependency_links=dependency_links
+    dependency_links=dependency_links,
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ requirements = [
     "textstat",
     "nltk",
     "language-tool-python",
-    "textblob"
+    "textblob",
+    "langid"
 ]
 
 setup_requirements = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py35, py36, flake8
+envlist = py35, py36, py312, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
+    3.12: py312
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
# Add support for newer python versions

## Background

Running `pip install coast_core` produces an error when using newer versions of python, such as python 3.12:

```
ERROR: Failed building wheel for language-check
```

Using coast_core with a newer version of python is likely to be desirable in certain cases. For instance, when building a streamlit app, only versions greater than 3.8 are supported (source: https://docs.streamlit.io/knowledge-base/using-streamlit/sanity-checks).

## What's been done

This pull request makes two main changes to coast_core that aim to make it compatible with newer versions of python.

1. **Swap out `language_check` with `language_tool_python`.** It appears the former is no longer maintained, and the latter is a wrapper around the same base tool (so should fulfil the same purpose).
2. **Swap out `lang_detect` with `langid`.** Similarly, the former doesn't look like it is maintained anymore. The latter functions a little differently and returns a tuple that contains the language code (i.e., en). Changes have been made to account for this difference.

## What's still to do

I have done some crude tests using a local install of the modified package (and it appears to work). However, I haven't executed the full range of tests outlined in `CONTRIBUTING.rst` (although I have updated the tox file) to test for the new environment.

Any advice / support in completing this testing is much appreciated.